### PR TITLE
Update Project create_from_request with get_object_or_404

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ venv
 
 # OS
 .DS_Store
+
+# vscode
+.vscode

--- a/panalytics/core/models.py
+++ b/panalytics/core/models.py
@@ -1,8 +1,10 @@
-from django.db import models
-from urllib.parse import urlparse
-from django.utils import timezone
-from django.db.models import Count
 import re
+
+from django.db import models
+from django.db.models import Count
+from django.utils import timezone
+from django.shortcuts import get_object_or_404
+from urllib.parse import urlparse
 
 from .utils import get_tracking_id
 
@@ -79,7 +81,7 @@ class PageView(models.Model):
 
     @staticmethod
     def create_from_request(request):
-        project = Project.objects.get(tid=request.GET.get('tid'))
+        project = get_object_or_404(Project, tid=request.GET.get('tid'))
         parsed_url = urlparse(request.GET.get('url'))
         ref = request.GET.get('ref')
 

--- a/panalytics/core/tests/test_model_pageview.py
+++ b/panalytics/core/tests/test_model_pageview.py
@@ -33,7 +33,7 @@ def get_request_url_title_dimensions():
     return RequestFactory().get('/a.gif', query)
 
 
-@patch('panalytics.core.models.Project.objects.get')
+@patch('panalytics.core.models.get_object_or_404')
 @patch('panalytics.core.models.PageView.objects.create')
 def test_create_from_request_passes_url_to_obj_create(
     mock_pageview_objects_create, mock_project_objects_get, get_request_url
@@ -47,7 +47,7 @@ def test_create_from_request_passes_url_to_obj_create(
     assert kwargs['url'] == 'http://example.com'
 
 
-@patch('panalytics.core.models.Project.objects.get')
+@patch('panalytics.core.models.get_object_or_404')
 @patch('panalytics.core.models.PageView.objects.create')
 def test_create_from_request_passes_default_referer_to_obj_create(
     mock_pageview_objects_create, mock_project_objects_get, get_request_url
@@ -58,7 +58,7 @@ def test_create_from_request_passes_default_referer_to_obj_create(
     assert kwargs['referer'] == ''
 
 
-@patch('panalytics.core.models.Project.objects.get')
+@patch('panalytics.core.models.get_object_or_404')
 @patch('panalytics.core.models.PageView.objects.create')
 def test_create_from_request_passes_referer_to_obj_create(
     mock_pageview_objects_create,
@@ -71,7 +71,7 @@ def test_create_from_request_passes_referer_to_obj_create(
     assert kwargs['referer'] == 'http://refer.com'
 
 
-@patch('panalytics.core.models.Project.objects.get')
+@patch('panalytics.core.models.get_object_or_404')
 @patch('panalytics.core.models.PageView.objects.create')
 def test_create_from_request_passes_source_as_referer_to_obj_create(
     mock_pageview_objects_create, mock_project_objects_get
@@ -84,7 +84,7 @@ def test_create_from_request_passes_source_as_referer_to_obj_create(
     assert kwargs['referer'] == 'email'
 
 
-@patch('panalytics.core.models.Project.objects.get')
+@patch('panalytics.core.models.get_object_or_404')
 @patch('panalytics.core.models.PageView.objects.create')
 def test_create_from_request_passes_referer_instead_or_source_to_obj_create(
     mock_pageview_objects_create, mock_project_objects_get
@@ -97,7 +97,7 @@ def test_create_from_request_passes_referer_instead_or_source_to_obj_create(
     assert kwargs['referer'] == 'http://refer.com'
 
 
-@patch('panalytics.core.models.Project.objects.get')
+@patch('panalytics.core.models.get_object_or_404')
 @patch('panalytics.core.models.PageView.objects.create')
 def test_create_from_request_passes_url_with_path_to_obj_create(
     mock_pageview_objects_create,
@@ -113,7 +113,7 @@ def test_create_from_request_passes_url_with_path_to_obj_create(
     assert kwargs['url'] == 'http://example.com/about'
 
 
-@patch('panalytics.core.models.Project.objects.get')
+@patch('panalytics.core.models.get_object_or_404')
 @patch('panalytics.core.models.PageView.objects.create')
 def test_create_from_request_passes_correct_title_to_obj_create(
     mock_pageview_objects_create,
@@ -126,7 +126,7 @@ def test_create_from_request_passes_correct_title_to_obj_create(
     assert kwargs['title'] == 'Test Title'
 
 
-@patch('panalytics.core.models.Project.objects.get')
+@patch('panalytics.core.models.get_object_or_404')
 @patch('panalytics.core.models.PageView.objects.create')
 def test_create_from_request_passes_default_title_to_obj_create(
     mock_pageview_objects_create, mock_project_objects_get, get_request_url
@@ -137,7 +137,7 @@ def test_create_from_request_passes_default_title_to_obj_create(
     assert kwargs['title'] == ''
 
 
-@patch('panalytics.core.models.Project.objects.get')
+@patch('panalytics.core.models.get_object_or_404')
 @patch('panalytics.core.models.PageView.objects.create')
 def test_create_from_request_passes_correct_window_dimensions_to_obj_create(
     mock_pageview_objects_create,
@@ -151,7 +151,7 @@ def test_create_from_request_passes_correct_window_dimensions_to_obj_create(
     assert kwargs['window_height'] == '675'
 
 
-@patch('panalytics.core.models.Project.objects.get')
+@patch('panalytics.core.models.get_object_or_404')
 @patch('panalytics.core.models.PageView.objects.create')
 def test_create_from_request_passes_default_window_dimensions_when_empty(
     mock_pageview_objects_create,
@@ -165,7 +165,7 @@ def test_create_from_request_passes_default_window_dimensions_when_empty(
     assert kwargs['window_height'] == '0'
 
 
-@patch('panalytics.core.models.Project.objects.get')
+@patch('panalytics.core.models.get_object_or_404')
 @patch('panalytics.core.models.PageView.objects.create')
 def test_create_from_request_passes_unique_visit_to_obj_create(
     mock_pageview_objects_create,
@@ -178,7 +178,7 @@ def test_create_from_request_passes_unique_visit_to_obj_create(
     assert kwargs['unique_visit']
 
 
-@patch('panalytics.core.models.Project.objects.get')
+@patch('panalytics.core.models.get_object_or_404')
 @patch('panalytics.core.models.PageView.objects.create')
 def test_create_from_request_not_unique_visit_if_url_referer_domain_the_same(
     mock_pageview_objects_create, mock_project_objects_get

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ Django==3.0.3
 pytest-django==3.8.0
 python-decouple==3.3
 coverage==5.0.3
+psycopg2-binary==2.8.5


### PR DESCRIPTION
Use get_object_or_404 instead of get when looking up Project during PageView creation.

Update requirements.txt with psycopg2-binary.

Update .gitignore to ignore vscode folder.